### PR TITLE
use apt to install oneapi

### DIFF
--- a/docker-recipes/runner/ubuntu22.04-amd64-oneapi-2024.1.0/Dockerfile
+++ b/docker-recipes/runner/ubuntu22.04-amd64-oneapi-2024.1.0/Dockerfile
@@ -1,16 +1,38 @@
-FROM intel/hpckit:2024.1.0-devel-ubuntu22.04 as base
+FROM ubuntu:22.04 as base
 
 ARG DEBIAN_FRONTEND=noninteractive
+ARG ONEAPI_VERSION=2024.1
 ENV TZ=America/Los_Angeles
 
 RUN apt update -y \
  && apt upgrade -y
 
-RUN wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB \ | gpg --dearmor | tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null \
- && echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | tee /etc/apt/sources.list.d/oneAPI.list
+RUN apt install -y gpg-agent wget ca-certificates \
+    && wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | \
+       gpg --dearmor | tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null \
+    && echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | \
+       tee /etc/apt/sources.list.d/oneAPI.list \
+    && . /etc/os-release \
+    && wget -qO - https://repositories.intel.com/gpu/intel-graphics.key | \
+       gpg --yes --dearmor --output /usr/share/keyrings/intel-graphics.gpg \
+    && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/intel-graphics.gpg] https://repositories.intel.com/gpu/ubuntu ${VERSION_CODENAME}/lts/2350 unified" | \
+       tee /etc/apt/sources.list.d/intel-gpu-${VERSION_CODENAME}.list \
+    && apt update -y \
+    && apt install -y intel-oneapi-compiler-fortran-${ONEAPI_VERSION} \
+         intel-oneapi-compiler-dpcpp-cpp-${ONEAPI_VERSION} \
+         intel-opencl-icd \
+         intel-level-zero-gpu \
+         intel-media-va-driver-non-free \
+         libmfx1 \
+         libigc-dev \
+         intel-igc-cm \
+         libigdfcl-dev \
+         libigfxcmrt-dev \
+         level-zero-dev \
+         clinfo \
+         libdrm-dev
 
-RUN apt update -y \
- && apt install -y \
+RUN apt install -y \
   autoconf \
   automake \
   bzip2 \
@@ -83,20 +105,6 @@ RUN export S=/tmp/spack \
  && spack clean -a \
  && rm -rf $S spack.yaml spack.lock concretize.log .spack-env Makefile ~/.spack
 
-RUN apt update -y \
- && apt install -y \
-  intel-opencl-icd \
-  intel-level-zero-gpu \
-  intel-media-va-driver-non-free \
-  libmfx1 \
-  libigc-dev \
-  intel-igc-cm \
-  libigdfcl-dev \
-  libigfxcmrt-dev \
-  level-zero-dev \
-  clinfo \
-  libdrm-dev
-
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
  && unzip awscliv2.zip \
  && ./aws/install \
@@ -110,10 +118,10 @@ RUN echo export PATH=$BOOTSTRAP_DIR/view/bin:'${PATH}' >> /etc/bash.bashrc \
 && echo module use /modules >> /etc/bash.bashrc \
 && echo module use /opt/intel/oneapi/modulefiles/ >> /etc/bash.bashrc
 
-ENV PATH=$BOOTSTRAP_DIR/view/bin:$PATH
-ENV LD_LIBRARY_PATH=/opt/intel/oneapi/compiler/2024.1/lib:$LD_LIBRARY_PATH
+ENV PATH=/opt/intel/oneapi/compiler/${ONEAPI_VERSION}/bin:$BOOTSTRAP_DIR/view/bin:$PATH
+ENV LD_LIBRARY_PATH=/opt/intel/oneapi/compiler/${ONEAPI_VERSION}/lib:$LD_LIBRARY_PATH
 
-RUN echo /opt/intel/oneapi/compiler/2024.1/lib >> /etc/ld.so.conf.d/oneapi.conf \
+RUN echo /opt/intel/oneapi/compiler/${ONEAPI_VERSION}/lib >> /etc/ld.so.conf.d/oneapi.conf \
  && ldconfig -v
 
 RUN updatedb

--- a/docker-recipes/runner/ubuntu22.04-amd64-oneapi-2024.1.0/build.sh
+++ b/docker-recipes/runner/ubuntu22.04-amd64-oneapi-2024.1.0/build.sh
@@ -7,9 +7,10 @@ fi
 
 BUILD_TYPE=$1
 
+ONEAPI_VERSION=${ONEAPI_VERSION:-2024.1}
 BUILD_DATE=$(printf '%(%Y.%m.%d)T' -1)
 BUILD_TAG=${BUILD_TAG:-${BUILD_DATE}}
-BUILD_NAME=ubuntu22.04-runner-amd64-oneapi-2024.1.0
+BUILD_NAME=ubuntu22.04-runner-amd64-oneapi-${ONEAPI_VERSION}
 if [[ "$BUILD_TYPE" == "base" ]]; then
   BUILD_NAME=${BUILD_NAME}-base
 fi
@@ -18,6 +19,7 @@ REGISTRY=${REGISTRY:-ecpe4s}
 OUTPUT_IMAGE="${REGISTRY}/${BUILD_NAME}:${BUILD_TAG}"
 
 docker build \
+ --build-arg ONEAPI_VERSION=${ONEAPI_VERSION} \
  --target ${BUILD_TYPE} \
  -t "${OUTPUT_IMAGE}" \
  .


### PR DESCRIPTION
Change oneapi container from using hpckit docker image to use apt to install icx/ifx. These are the benefits:
* reduces container footprint from 16 GB to 6GB
* apt release is available earlier than docker images
* easier to test compiler when no hpckit image is available: patch releases and special releases

I changed the image name to  use major.minor instead of major.minor.patch. This was motivated by the 2024 switch to using major.minor for package name and wanting to use the same name as the package name. Note that the gcc docker images are also major.minor.  If you prefer to have major.minor.patch in image name, I can change it.

I tested this with 2024.1.2 release and all gitlab spack tests pass